### PR TITLE
Fixed cleansing platforms after invert - wrong platform

### DIFF
--- a/RaidNotifier.xml
+++ b/RaidNotifier.xml
@@ -103,28 +103,28 @@
 
 					<Controls>
 						<Backdrop name="$(parent)BG" inherits="ZO_DefaultBackdrop"/>
-						
+
 						<Control name="$(parent)Glyph1" inherits="RaidNotifierGlyphTemplate">
-							<Anchor point="TOP" offsetX="90" offsetY="0" />
+							<Anchor point="TOPLEFT" offsetX="180" offsetY="0" />
 						</Control>
 						<Control name="$(parent)Glyph2" inherits="RaidNotifierGlyphTemplate">
-							<Anchor point="TOP" offsetX="78" offsetY="60" />
+							<Anchor point="TOPLEFT" offsetX="168" offsetY="60" />
 						</Control>
 						<Control name="$(parent)Glyph3" inherits="RaidNotifierGlyphTemplate">
-							<Anchor point="TOP" offsetX="30" offsetY="110" />
+							<Anchor point="TOPLEFT" offsetX="120" offsetY="110" />
 						</Control>
 						<Control name="$(parent)Glyph4" inherits="RaidNotifierGlyphTemplate">
-							<Anchor point="TOP" offsetX="-30" offsetY="110" />
+							<Anchor point="TOPLEFT" offsetX="60" offsetY="110" />
 						</Control>
 						<Control name="$(parent)Glyph5" inherits="RaidNotifierGlyphTemplate">
-							<Anchor point="TOP" offsetX="-78" offsetY="60" />
+							<Anchor point="TOPLEFT" offsetX="12" offsetY="60" />
 						</Control>
 						<Control name="$(parent)Glyph6" inherits="RaidNotifierGlyphTemplate">
-							<Anchor point="TOP" offsetX="-90" offsetY="0" />
+							<Anchor point="TOPLEFT" offsetX="0" offsetY="0" />
 						</Control>
 						<Control name="$(parent)Glyph7" inherits="RaidNotifierGlyphTemplate">
-							<Anchor point="TOP" offsetX="0" offsetY="20" />
-						</Control>
+							<Anchor point="TOPLEFT" offsetX="90" offsetY="20" />
+						</Control>						
 
 					</Controls>
 				</Control>

--- a/UI.lua
+++ b/UI.lua
@@ -103,11 +103,13 @@ do -----------------
 			local isValidAnchor, point, relativeTo, relativePoint, offsetX, offsetY = control:GetAnchor()
 			control:ClearAnchors()
 			offsetY = math.abs(offsetY)
+			offsetX = math.abs(offsetX)
 			if inverted then
-				point = BOTTOM
+				point = BOTTOMRIGHT
 				offsetY = offsetY * -1
+				offsetX = offsetX * -1
 			else
-				point = TOP
+				point = TOPLEFT
 			end
 			control:SetAnchor(point, nil, nil, offsetX, offsetY)
 		end


### PR DESCRIPTION
It seems to be a bug of sides where platforms are after invert:
http://imgur.com/a/GflyM
On the left picture you should see how it looks like when i take right up platform. But turning it around (changing perspective) should go down left (not down right).
After this patch:
http://imgur.com/a/hE6iz