### PR TITLE
Glyphs window display bugfix

### DIFF
--- a/RaidNotifier.lua
+++ b/RaidNotifier.lua
@@ -553,14 +553,14 @@ do -----------------------------
 
 			UI.SetElementHidden("mawLorkhaj", "zhaj_glyph_window", true)
 			local map       = GetMapTileTexture()
-			if (bossCount == 1 and map == "Art/maps/reapersmarch/Maw_of_Lorkaj_Base_0.dds") then -- Zhaj'hassa the Forgotten
+			if (bossCount == 1 and map == UI.MAP_MOL_BASE) then -- Zhaj'hassa the Forgotten
 				buffsDebuffs.zhajBoss_knownGlyphs = {}
 				if (settings.zhaj_glyphs) then
 					UI.SetElementHidden("mawLorkhaj", "zhaj_glyph_window", false)
 				end
-			elseif (bossCount == 2 and map == "Art/maps/reapersmarch/MawLorkajSuthaySanctuary_Base_0.dds") then -- False Moon Twins, S’Kinrai and Vashai
+			elseif (bossCount == 2 and map == UI.MAP_MOL_SUTHAY_SANCTUARY) then -- False Moon Twins, S’Kinrai and Vashai
 				
-			elseif (bossCount == 1 and map == "Art/maps/reapersmarch/MawLorkajSevenRiddles_Base_0.dds") then
+			elseif (bossCount == 1 and map == UI.MAP_MOL_SEVEN_RIDDLES) then
 			
 			end
 		elseif (raidId == RAID_HALLS_OF_FABRICATION) then

--- a/Settings.lua
+++ b/Settings.lua
@@ -542,7 +542,11 @@ function RaidNotifier:CreateSettingsMenu()
 		getFunc = function() return Vars.mawLorkhaj.zhaj_glyphs end,
 		setFunc = function(value)   
 					Vars.mawLorkhaj.zhaj_glyphs = value 
-					self.UI.SetElementHidden("mawLorkhaj", "zhaj_glyph_window", not value)
+					local map       = GetMapTileTexture()
+					local numBoss = self:GetNumBosses(true)
+					if (value == false or (numBoss == 1 and map == UI.MAP_MOL_BASE)) then
+						self.UI.SetElementHidden("mawLorkhaj", "zhaj_glyph_window", not value)
+					end
 				end,
 		noSound = true,
 	}, "mawLorkhaj", "zhaj_glyphs")

--- a/UI.lua
+++ b/UI.lua
@@ -69,6 +69,10 @@ do -----------------
 
 	local window  = nil 
 
+	UI.MAP_MOL_BASE = "Art/maps/reapersmarch/Maw_of_Lorkaj_Base_0.dds"
+	UI.MAP_MOL_SUTHAY_SANCTUARY = "Art/maps/reapersmarch/MawLorkajSuthaySanctuary_Base_0.dds"
+	UI.MAP_MOL_SEVEN_RIDDLES = "Art/maps/reapersmarch/MawLorkajSevenRiddles_Base_0.dds"
+
 	function UI.StartGlyphTimer(index, cooldown)
 		window = window or UI.GetElement("mawLorkhaj", "zhaj_glyph_window")
 		if not window then return end


### PR DESCRIPTION
Turning off and then on glyphs window inside any trial will display that window even if we are not in vMoL.
This window should be available only for the first boss.
