### PR TITLE
Fixed draining ballista notification for others

### DIFF
--- a/RaidNotifier.lua
+++ b/RaidNotifier.lua
@@ -1273,7 +1273,9 @@ do ---------------------------
 					if (settings.draining_ballista >= 1) then
 						tName = LUNIT:GetNameForUnitId(tUnitId) --isn't supplied by event for group members, only for the player
 						if (tType == COMBAT_UNIT_TYPE_PLAYER) then
-							self:AddAnnouncement(GetString(RAIDNOTIFIER_ALERTS_HALLSFAB_DRAINING_BALLISTA), "hallsFab", "draining_ballista", 4)
+							self:AddAnnouncement(GetString(RAIDNOTIFIER_ALERTS_HALLSFAB_DRAINING_BALLISTA), "hallsFab", "draining_ballista", 4) -- do we need this 4sec delay?
+						elseif (tName ~= "" and settings.draining_ballista == 2) then
+							self:AddAnnouncement(GetString(RAIDNOTIFIER_ALERTS_HALLSFAB_DRAINING_BALLISTA_OTHER), "hallsFab", "draining_ballista", 4)
 						end
 					end
 				elseif (abilityId == buffsDebuffs.power_leech) then

--- a/Settings.lua
+++ b/Settings.lua
@@ -89,7 +89,7 @@ RaidNotifier.Defaults = {
 	hallsFab = {
 		conduit_strike        = true, 
 		taking_aim            = 1, -- "Self"
-		draining_ballista     = 1, --
+		draining_ballista     = 1, -- "Self"
 		power_leech           = false,
 
 		pinnacleBoss_conduit_spawn = true,

--- a/lang/en.lua
+++ b/lang/en.lua
@@ -302,6 +302,7 @@ L.Alerts_HallsFab_Conduit_Drain                     = "A Conduit is draining you
 L.Alerts_HallsFab_Conduit_Drain_Other               = "A Conduit is draining |cFF0000<<!aC:1>>|r!"
 L.Alerts_HallsFab_Conduit_Strike                    = "Incoming |cFF0000Conduit Strike|r. Block!"
 L.Alerts_HallsFab_Draining_Ballista                 = "|cFFC000Draining Ballista|r targeted at you! Block or interrupt!"
+L.Alerts_HallsFab_Draining_Ballista_Other           = "|cFFC000Draining Ballista|r targeted at |cFF0000<<!aC:1>>|r! Interrupt!"
 L.Alerts_HallsFab_Power_Leech                       = "|c6600FFPower Leech|r! Break Free!"
 L.Alerts_HallsFab_Overcharge_Aura                   = "|c3366EEOvercharging Aura|r at Reclaimer."
 L.Alerts_HallsFab_Overpower_Auras                   = "|cFF0000Aura Countdown!|r"


### PR DESCRIPTION
Draining ballista can be set as off, self or all.
Before this patch self was the same as all.