### PR TITLE
Fix Zhaj'hassa's cleansing platforms error report when setting it up

### DIFF
--- a/Settings.lua
+++ b/Settings.lua
@@ -1060,9 +1060,13 @@ function RaidNotifier:CreateSettingsMenu()
 		name = L.Settings_MawLorkhaj_Zhaj_Glyphs,
 		tooltip = L.Settings_MawLorkhaj_Zhaj_Glyphs_TT,
 		getFunc = function() return savedVars.mawLorkhaj.zhaj_glyphs end,
-		setFunc = function(value)   
-					savedVars.mawLorkhaj.zhaj_glyphs = value 
-					RaidNotifier.OnBossesChanged()
+		setFunc = function(value)
+					savedVars.mawLorkhaj.zhaj_glyphs = value
+
+					if self.raidId == RAID_MAW_OF_LORKHAJ then
+					    -- Updating glyph window visibility state
+					    self.MOL.OnBossesChanged()
+					end
 				end,
 		noAlert = true,
 	}, "mawLorkhaj", "zhaj_glyphs")


### PR DESCRIPTION
All right, that seems easy.

In https://github.com/kyoma/ESO-RaidNotifier/commit/40048ba there was introduced OnBossesChanged() call aimed to switch panel visibility without reloading UI.
But there was some big refactoring in https://github.com/kyoma/ESO-RaidNotifier/commit/dc16258, so OnBossesChanged() got separated for several trial-related files.
But setter for cleansing platform setting wasn't touched, so now it calls for a UI bug (unexisting function).
Still it works fine, but UI error was confusing, and UI reload was required.

It isn't really clean solution to call such event handler for updating UI element visibility, but it'll work as intended earlier, and also doesn't requires extra code.