### PR TITLE
Fix displaying digits instead of username in some cases (cache miss in LibUnits2 in case of reloading UI / relog happened)

### DIFF
--- a/libs/LibUnits2/LibUnits2.lua
+++ b/libs/LibUnits2/LibUnits2.lua
@@ -99,7 +99,7 @@ local function Load()
 
 	-- During group invitation, we can receive a lot of event spam at once on a single invite when the
 	-- involved players are at the same location. Add a delay so we only refresh once in cases like this.
-	lib.delayedRebuildCounter = 0 
+	lib.delayedRebuildCounter = 0
     local function DelayedRefreshData()
         lib.delayedRebuildCounter = lib.delayedRebuildCounter - 1
         if lib.delayedRebuildCounter == 0 then

--- a/libs/LibUnits2/LibUnits2.lua
+++ b/libs/LibUnits2/LibUnits2.lua
@@ -129,6 +129,9 @@ local function Load()
 	EVENT_MANAGER:RegisterForEvent("LibUnits2_EffectChangedBoss",  EVENT_EFFECT_CHANGED, OnBossEffectChanged)
 	EVENT_MANAGER:AddFilterForEvent("LibUnits2_EffectChangedBoss", EVENT_EFFECT_CHANGED, REGISTER_FILTER_UNIT_TAG_PREFIX, "boss")
 
+	-- We'd like to have relevant data after reloading UI or relogging
+	lib.RefreshUnits()
+
 	lib.Unload = Unload
 end
 

--- a/libs/LibUnits2/LibUnits2.txt
+++ b/libs/LibUnits2/LibUnits2.txt
@@ -1,7 +1,7 @@
 ﻿## Title: LibUnits2
-## APIVersion: 100030
+## APIVersion: 100034
 ## Author: andy.s
-## AddOnVersion: 100
+## AddOnVersion: 101
 ## IsLibrary: true
 
 LibUnits2.lua


### PR DESCRIPTION
If player reloads his UI or relogs, and group doesn't change, there are no stored data.
That's why RefreshUnits() added to loading proccess of LibUnits2.

You can face with this issue in case you're in the trial, need to reload UI for instance, and group remained the same. Next announcements which will include player name will contain digits instead of name.