### PR TITLE
ESO API version bump (compatible with Blackwood)

### DIFF
--- a/RaidNotifier.txt
+++ b/RaidNotifier.txt
@@ -2,7 +2,7 @@
 ## Description: Displays on-screen notifications on different events during trials.
 ## Author: |c009ad6Kyoma, Memus, Woeler, silentgecko|r
 ## Version: 2.18
-## APIVersion: 100034
+## APIVersion: 100035
 ## SavedVariables: RNVars RN_DEBUG_LOG
 ## DependsOn: LibAddonMenu-2.0>=28 LibUnits2
 ## OptionalDependsOn: LibGroupSocket


### PR DESCRIPTION
AddOn version was already bumped (we didn't release it yet).

So now changelog looks like:
- Added Spanish translation (thanks to Leviatan64, Inval1d)
- Marked as compatible with Blackwood (API version bump)

Maybe it's good idea to release it as it is for now.