### PR TITLE
Version 2.18.1: bump API version (compatible with Waking Flame)

### DIFF
--- a/RaidNotifier.txt
+++ b/RaidNotifier.txt
@@ -1,8 +1,8 @@
 ## Title: |cEFEBBERaidNotifier|r
 ## Description: Displays on-screen notifications on different events during trials.
 ## Author: |c009ad6Kyoma, Memus, Woeler, silentgecko|r
-## Version: 2.18
-## APIVersion: 100035
+## Version: 2.18.1
+## APIVersion: 101031
 ## SavedVariables: RNVars RN_DEBUG_LOG
 ## DependsOn: LibAddonMenu-2.0>=28 LibUnits2
 ## OptionalDependsOn: LibGroupSocket


### PR DESCRIPTION
Looks like RaidNotifier works fine with the new update. API changelog didn't contain anything significant towards raids as well.