### PR TITLE
Fixing Oaxiltso's Noxious Sludge announcement at the Rockgrove trial

### DIFF
--- a/RaidNotifier.lua
+++ b/RaidNotifier.lua
@@ -5,7 +5,7 @@ local RaidNotifier = RaidNotifier
 
 RaidNotifier.Name           = "RaidNotifier"
 RaidNotifier.DisplayName    = "Raid Notifier"
-RaidNotifier.Version        = "2.19"
+RaidNotifier.Version        = "2.19.1"
 RaidNotifier.Author         = "|c009ad6Kyoma, Memus, Woeler, silentgecko|r"
 RaidNotifier.SV_Name        = "RNVars"
 RaidNotifier.SV_Version     = 4

--- a/RaidNotifier.txt
+++ b/RaidNotifier.txt
@@ -1,7 +1,7 @@
 ## Title: |cEFEBBERaidNotifier|r
 ## Description: Displays on-screen notifications on different events during trials.
 ## Author: |c009ad6Kyoma, Memus, Woeler, silentgecko|r
-## Version: 2.19
+## Version: 2.19.1
 ## APIVersion: 101032
 ## SavedVariables: RNVars RN_DEBUG_LOG
 ## DependsOn: LibAddonMenu-2.0>=28 LibUnits2

--- a/TrialRockgrove.lua
+++ b/TrialRockgrove.lua
@@ -33,7 +33,7 @@ function RaidNotifier.RG.OnEffectChanged(eventCode, changeType, eSlot, eName, uT
     -- Oaxiltso's Noxious Sludge
     elseif (abilityId == buffsDebuffs.oaxiltso_noxious_sludge and string.sub(uTag, 1, 5) == "group") then
         if (changeType == EFFECT_RESULT_GAINED) then
-            if (settings.oaxiltso_noxious_sludge >= 1 and AreUnitsEqual(uTag, "player")) then
+            if (settings.oaxiltso_noxious_sludge == 1 and AreUnitsEqual(uTag, "player")) then
                 self:AddAnnouncement(GetString(RAIDNOTIFIER_ALERTS_ROCKGROVE_NOXIOUS_SLUDGE_SELF), "rockgrove", "oaxiltso_noxious_sludge")
             elseif (settings.oaxiltso_noxious_sludge == 2) then
                 local targetPlayerName = self.UnitIdToString(uId)
@@ -42,13 +42,13 @@ function RaidNotifier.RG.OnEffectChanged(eventCode, changeType, eSlot, eName, uT
                     "oaxiltso_noxious_sludge",
                     targetPlayerName,
                     function (argsBag)
-                        if (argsBag:GetEventCount() >= 2) then
-                            self:AddAnnouncement(zo_strformat(GetString(RAIDNOTIFIER_ALERTS_ROCKGROVE_NOXIOUS_SLUDGE), unpack(argsBag:GetValues())), "rockgrove", "oaxiltso_noxious_sludge")
-                        else
-                            -- For some crazy people who'll go solo into the trial?
-                            self:AddAnnouncement(GetString(RAIDNOTIFIER_ALERTS_ROCKGROVE_NOXIOUS_SLUDGE_SELF), "rockgrove", "oaxiltso_noxious_sludge")
+                        local alertMessage = RAIDNOTIFIER_ALERTS_ROCKGROVE_NOXIOUS_SLUDGE_OTHER2
+
+                        if (argsBag:GetEventCount() == 1) then
+                            alertMessage = RAIDNOTIFIER_ALERTS_ROCKGROVE_NOXIOUS_SLUDGE_OTHER1
                         end
 
+                        self:AddAnnouncement(zo_strformat(GetString(alertMessage), unpack(argsBag:GetValues())), "rockgrove", "oaxiltso_noxious_sludge")
                     end,
                     50
                 )

--- a/lang/en.lua
+++ b/lang/en.lua
@@ -613,7 +613,8 @@ L.Alerts_Rockgrove_Prime_Meteor                    = "|cFFD600Prime Meteor|r wil
 L.Alerts_Rockgrove_Hasted_Assault                  = "Incoming |cFF0000Hasted Assault|r! Block!"
 L.Alerts_Rockgrove_Savage_Blitz                    = "Oaxiltso charges at |cFF0000<<!aC:1>>|r!"
 L.Alerts_Rockgrove_Noxious_Sludge_Self             = "You're poisoned by |c008C22Noxious Sludge|r! Cleanse in the pool!"
-L.Alerts_Rockgrove_Noxious_Sludge                  = "|cFF0000<<!aC:1>>|r and |cFF0000<<!aC:2>>|r are poisoned by |c008C22Noxious Sludge|r."
+L.Alerts_Rockgrove_Noxious_Sludge_Other1           = "|cFF0000<<!aC:1>>|r is poisoned by |c008C22Noxious Sludge|r."
+L.Alerts_Rockgrove_Noxious_Sludge_Other2           = "|cFF0000<<!aC:1>>|r and |cFF0000<<!aC:2>>|r are poisoned by |c008C22Noxious Sludge|r."
 L.Alerts_Rockgrove_Embrace_Of_Death                = "You're cursed by |c370073Embrace of Death|r! Stay away! Explosion in"
 L.Alerts_Rockgrove_Embrace_Of_Death_Other          = "|cFF0000<<!aC:1>>|r cursed by |c370073Embrace of Death|r! Explosion in"
 


### PR DESCRIPTION
Thanks to the fact that Rockgrove mechs were published it's more tested by more people now, and our team faced with the situation when they don't receive notification about other afflictions of boss poison while having poison themselves.

It's not a fatal issue but still unpleasant one, so I made a fix for this. Also I made some additional adjustments to be sure it will work even if things will go unexpected way. Maybe it won't be needed and will be removed, but best to be safe than sorry for now.

For the CHANGELOG (as an example ofc):
Fixed Oaxiltso's Noxious Sludge announcement at the Rockgrove trial: now you will properly receive the names of your teammates being poisoned when "All" option is selected, regardless of whether you are poisoned yourself.