### PR TITLE
Version 2.21.1: Fixing UI error that appears during foodbuff duration check (+API version bump)

### DIFF
--- a/RaidNotifier.lua
+++ b/RaidNotifier.lua
@@ -5,7 +5,7 @@ local RaidNotifier = RaidNotifier
 
 RaidNotifier.Name           = "RaidNotifier"
 RaidNotifier.DisplayName    = "Raid Notifier"
-RaidNotifier.Version        = "2.21"
+RaidNotifier.Version        = "2.21.1"
 RaidNotifier.Author         = "|c009ad6Kyoma, Memus, Woeler, silentgecko|r"
 RaidNotifier.SV_Name        = "RNVars"
 RaidNotifier.SV_Version     = 4

--- a/RaidNotifier.lua
+++ b/RaidNotifier.lua
@@ -528,10 +528,10 @@ do ----------------------
 			or GetAbilityDuration(abilityId) < 600000 then
 				return false
 			end
-			local cost, mechanic = GetAbilityCost(abilityId)
+			local cost = GetAbilityCost(abilityId)
 			local channeled, castTime = GetAbilityCastInfo(abilityId)
 			local minRangeCM, maxRangeCM = GetAbilityRange(abilityId)
-			if cost > 0 or mechanic > 0 or channeled or castTime > 0 or minRangeCM > 0 or maxRangeCM > 0 or GetAbilityDescription(abilityId) == "" then
+			if cost > 0 or channeled or castTime > 0 or minRangeCM > 0 or maxRangeCM > 0 or GetAbilityDescription(abilityId) == "" then
 				return false
 			end
 			return true

--- a/RaidNotifier.txt
+++ b/RaidNotifier.txt
@@ -2,7 +2,7 @@
 ## Description: Displays on-screen notifications on different events during trials.
 ## Author: |c009ad6Kyoma, Memus, Woeler, silentgecko|r
 ## Version: 2.21
-## APIVersion: 101033
+## APIVersion: 101034
 ## SavedVariables: RNVars RN_DEBUG_LOG
 ## DependsOn: LibAddonMenu-2.0>=28 LibUnits2
 ## OptionalDependsOn: LibGroupSocket

--- a/RaidNotifier.txt
+++ b/RaidNotifier.txt
@@ -1,7 +1,7 @@
 ## Title: |cEFEBBERaidNotifier|r
 ## Description: Displays on-screen notifications on different events during trials.
 ## Author: |c009ad6Kyoma, Memus, Woeler, silentgecko|r
-## Version: 2.21
+## Version: 2.21.1
 ## APIVersion: 101034
 ## SavedVariables: RNVars RN_DEBUG_LOG
 ## DependsOn: LibAddonMenu-2.0>=28 LibUnits2


### PR DESCRIPTION
CHANGELOG:
- Fixed UI error that appeared during foodbuff duration check
- API version bump (High Isle chapter)

---

The bug is extremely annoying. I tested the solution and it seems to work fine, but even if it'll have some pitfalls it'll be totally better than UI error spawning every 1 second and blocking everything which is currently present.