### PR TITLE
Version 2.22: some Dreadsail Reef trial mechanics

### DIFF
--- a/BuffsDebuffs.lua
+++ b/BuffsDebuffs.lua
@@ -647,4 +647,9 @@ RaidNotifier.BuffsDebuffs[RAID_ROCKGROVE] = rockgrove
 -- -- ---------------------------------------------------
 local dreadsail_reef = {}
 
+-- Lylanar's Imminent Blister debuff (will be followed by Blistering Fragility; attack ID = 166522)
+dreadsail_reef.lylanar_imminent_blister = 168525
+-- Turlassil's Imminent Chill debuff (will be followed by Chilling Fragility; attack ID = 166527)
+dreadsail_reef.turlassil_imminent_chill = 168526
+
 RaidNotifier.BuffsDebuffs[RAID_DREADSAIL_REEF] = dreadsail_reef

--- a/BuffsDebuffs.lua
+++ b/BuffsDebuffs.lua
@@ -651,6 +651,10 @@ local dreadsail_reef = {}
 dreadsail_reef.lylanar_imminent_blister = 168525
 -- Turlassil's Imminent Chill debuff (will be followed by Chilling Fragility; attack ID = 166527)
 dreadsail_reef.turlassil_imminent_chill = 168526
+-- Lylanar's Heavy Attack
+dreadsail_reef.lylanar_broiling_hew = 167273
+-- Turlassil's Heavy Attack
+dreadsail_reef.turlassil_stinging_shear = 167280
 -- Tideborn Taleria's Rapid Deluge
 dreadsail_reef.taleria_rapid_deluge = {
 	[174959] = true, -- Normal

--- a/BuffsDebuffs.lua
+++ b/BuffsDebuffs.lua
@@ -655,6 +655,8 @@ dreadsail_reef.turlassil_imminent_chill = 168526
 dreadsail_reef.lylanar_broiling_hew = 167273
 -- Turlassil's Heavy Attack
 dreadsail_reef.turlassil_stinging_shear = 167280
+-- Reef Guardian's cast on Reef Heart
+dreadsail_reef.reef_guardian_heartburn = 163692
 -- Tideborn Taleria's Rapid Deluge
 dreadsail_reef.taleria_rapid_deluge = {
 	[174959] = true, -- Normal

--- a/BuffsDebuffs.lua
+++ b/BuffsDebuffs.lua
@@ -641,3 +641,10 @@ rockgrove.meteor_radiating_heat = {
 rockgrove.bahsei_death_touch = 150078
 
 RaidNotifier.BuffsDebuffs[RAID_ROCKGROVE] = rockgrove
+
+-- ------------------------------------------------------
+-- -- Dreadsail Reef-------------------------------------
+-- -- ---------------------------------------------------
+local dreadsail_reef = {}
+
+RaidNotifier.BuffsDebuffs[RAID_DREADSAIL_REEF] = dreadsail_reef

--- a/BuffsDebuffs.lua
+++ b/BuffsDebuffs.lua
@@ -651,5 +651,11 @@ local dreadsail_reef = {}
 dreadsail_reef.lylanar_imminent_blister = 168525
 -- Turlassil's Imminent Chill debuff (will be followed by Chilling Fragility; attack ID = 166527)
 dreadsail_reef.turlassil_imminent_chill = 168526
+-- Tideborn Taleria's Rapid Deluge
+dreadsail_reef.taleria_rapid_deluge = {
+	[174959] = true, -- Normal
+	[174960] = true, -- Veteran
+	[174961] = true, -- Hardmode
+}
 
 RaidNotifier.BuffsDebuffs[RAID_DREADSAIL_REEF] = dreadsail_reef

--- a/RaidNotifier.lua
+++ b/RaidNotifier.lua
@@ -5,7 +5,7 @@ local RaidNotifier = RaidNotifier
 
 RaidNotifier.Name           = "RaidNotifier"
 RaidNotifier.DisplayName    = "Raid Notifier"
-RaidNotifier.Version        = "2.21.1"
+RaidNotifier.Version        = "2.22"
 RaidNotifier.Author         = "|c009ad6Kyoma, Memus, Woeler, silentgecko|r"
 RaidNotifier.SV_Name        = "RNVars"
 RaidNotifier.SV_Version     = 4

--- a/RaidNotifier.lua
+++ b/RaidNotifier.lua
@@ -24,6 +24,7 @@ RAID_BLACKROSE_PRISON       = 10
 RAID_SUNSPIRE               = 11
 RAID_KYNES_AEGIS            = 12
 RAID_ROCKGROVE              = 13
+RAID_DREADSAIL_REEF         = 14
 
 -- Debugging
 local function p() end
@@ -582,6 +583,7 @@ do ----------------------
 		[RAID_SUNSPIRE]              = 1121,
 		[RAID_KYNES_AEGIS]           = 1196,
 		[RAID_ROCKGROVE]             = 1263,
+		[RAID_DREADSAIL_REEF]        = 1344,
 	}
 
 	local RaidZones = {}
@@ -922,6 +924,7 @@ do ---------------------------
 	RaidNotifier.SS = RaidNotifier.SS or {}
 	RaidNotifier.KA = RaidNotifier.KA or {}
 	RaidNotifier.RG = RaidNotifier.RG or {}
+	RaidNotifier.DSR = RaidNotifier.DSR or {}
 
 	RaidNotifier.Trial =
 	{
@@ -937,6 +940,7 @@ do ---------------------------
 		[RAID_SUNSPIRE]	             = RaidNotifier.SS,
 		[RAID_KYNES_AEGIS]           = RaidNotifier.KA,
 		[RAID_ROCKGROVE]             = RaidNotifier.RG,
+		[RAID_DREADSAIL_REEF]        = RaidNotifier.DSR,
 	}
 
 	-------------------

--- a/RaidNotifier.txt
+++ b/RaidNotifier.txt
@@ -30,6 +30,7 @@ TrialCloudrest.lua
 TrialSunspire.lua
 TrialKynesAegis.lua
 TrialRockgrove.lua
+TrialDreadsailReef.lua
 
 Notifications.lua
 RaidNotifier.lua

--- a/RaidNotifier.txt
+++ b/RaidNotifier.txt
@@ -1,7 +1,7 @@
 ## Title: |cEFEBBERaidNotifier|r
 ## Description: Displays on-screen notifications on different events during trials.
 ## Author: |c009ad6Kyoma, Memus, Woeler, silentgecko|r
-## Version: 2.21.1
+## Version: 2.22
 ## APIVersion: 101034
 ## SavedVariables: RNVars RN_DEBUG_LOG
 ## DependsOn: LibAddonMenu-2.0>=28 LibUnits2

--- a/Settings.lua
+++ b/Settings.lua
@@ -319,6 +319,7 @@ do ------------------
 		},
 		dreadsailReef = {
 			imminent_debuffs = false,
+			brothers_heavy_attack = 0, -- "Off"
 			taleria_rapid_deluge = 0, -- "Off"
 		},
 		dbg = {
@@ -571,6 +572,7 @@ function RaidNotifier:CreateSettingsMenu()
 			bahsei_embrace_of_death = off_self_all,
 		},
 		dreadsailReef = {
+			brothers_heavy_attack = off_self_all,
 			taleria_rapid_deluge = off_self_all,
 		},
 	}
@@ -1723,6 +1725,12 @@ function RaidNotifier:CreateSettingsMenu()
 		name = L.Settings_DreadsailReef_Imminent_Debuffs,
 		tooltip = L.Settings_DreadsailReef_Imminent_Debuffs_TT,
 	}, "dreadsailReef", "imminent_debuffs")
+	MakeControlEntry({
+		type = "dropdown",
+		name = L.Settings_DreadsailReef_Brothers_Heavy_Attack,
+		tooltip = L.Settings_DreadsailReef_Brothers_Heavy_Attack_TT,
+		choices = choices.dreadsailReef.brothers_heavy_attack,
+	}, "dreadsailReef", "brothers_heavy_attack")
 	MakeControlEntry({
 		type = "dropdown",
 		name = L.Settings_DreadsailReef_Rapid_Deluge,

--- a/Settings.lua
+++ b/Settings.lua
@@ -320,6 +320,7 @@ do ------------------
 		dreadsailReef = {
 			imminent_debuffs = false,
 			brothers_heavy_attack = 0, -- "Off"
+			reef_guardian_reef_heart = false,
 			taleria_rapid_deluge = 0, -- "Off"
 		},
 		dbg = {
@@ -1731,6 +1732,11 @@ function RaidNotifier:CreateSettingsMenu()
 		tooltip = L.Settings_DreadsailReef_Brothers_Heavy_Attack_TT,
 		choices = choices.dreadsailReef.brothers_heavy_attack,
 	}, "dreadsailReef", "brothers_heavy_attack")
+	MakeControlEntry({
+		type = "checkbox",
+		name = L.Settings_DreadsailReef_ReefGuardian_ReefHeart,
+		tooltip = L.Settings_DreadsailReef_ReefGuardian_ReefHeart_TT,
+	}, "dreadsailReef", "reef_guardian_reef_heart")
 	MakeControlEntry({
 		type = "dropdown",
 		name = L.Settings_DreadsailReef_Rapid_Deluge,

--- a/Settings.lua
+++ b/Settings.lua
@@ -20,6 +20,7 @@ RAID_BLACKROSE_PRISON       = 10
 RAID_SUNSPIRE				= 11
 RAID_KYNES_AEGIS			= 12
 RAID_ROCKGROVE              = 13
+RAID_DREADSAIL_REEF         = 14
 
 -- ------------------
 -- DEFAULT SETTINGS
@@ -316,6 +317,8 @@ do ------------------
 			oaxiltso_annihilator_cinder_cleave = 0, -- "Off"
 			bahsei_embrace_of_death = 0, -- "Off"
 		},
+		dreadsailReef = {
+		},
 		dbg = {
 			enable = false,
 			notify = false,
@@ -564,6 +567,8 @@ function RaidNotifier:CreateSettingsMenu()
 			oaxiltso_noxious_sludge = off_self_all,
 			oaxiltso_annihilator_cinder_cleave = off_self_all,
 			bahsei_embrace_of_death = off_self_all,
+		},
+		dreadsailReef = {
 		},
 	}
 
@@ -1706,6 +1711,10 @@ function RaidNotifier:CreateSettingsMenu()
 		choices = choices.rockgrove.bahsei_embrace_of_death,
 		choicesTooltips = { false, false, L.Settings_Rockgrove_Embrace_Of_Death_TT_All },
 	}, "rockgrove", "bahsei_embrace_of_death")
+	subTable = nil --end submenu
+
+	-- Dreadsail Reef
+	MakeSubmenu(L.Settings_DreadsailReef_Header, RaidNotifier:GetRaidDescription(RAID_DREADSAIL_REEF))
 	subTable = nil --end submenu
 
 	MakeControlEntry({

--- a/Settings.lua
+++ b/Settings.lua
@@ -319,6 +319,7 @@ do ------------------
 		},
 		dreadsailReef = {
 			imminent_debuffs = false,
+			taleria_rapid_deluge = 0, -- "Off"
 		},
 		dbg = {
 			enable = false,
@@ -570,6 +571,7 @@ function RaidNotifier:CreateSettingsMenu()
 			bahsei_embrace_of_death = off_self_all,
 		},
 		dreadsailReef = {
+			taleria_rapid_deluge = off_self_all,
 		},
 	}
 
@@ -1721,6 +1723,12 @@ function RaidNotifier:CreateSettingsMenu()
 		name = L.Settings_DreadsailReef_Imminent_Debuffs,
 		tooltip = L.Settings_DreadsailReef_Imminent_Debuffs_TT,
 	}, "dreadsailReef", "imminent_debuffs")
+	MakeControlEntry({
+		type = "dropdown",
+		name = L.Settings_DreadsailReef_Rapid_Deluge,
+		tooltip = L.Settings_DreadsailReef_Rapid_Deluge_TT,
+		choices = choices.dreadsailReef.taleria_rapid_deluge,
+	}, "dreadsailReef", "taleria_rapid_deluge")
 	subTable = nil --end submenu
 
 	MakeControlEntry({

--- a/Settings.lua
+++ b/Settings.lua
@@ -318,6 +318,7 @@ do ------------------
 			bahsei_embrace_of_death = 0, -- "Off"
 		},
 		dreadsailReef = {
+			imminent_debuffs = false,
 		},
 		dbg = {
 			enable = false,
@@ -1715,6 +1716,11 @@ function RaidNotifier:CreateSettingsMenu()
 
 	-- Dreadsail Reef
 	MakeSubmenu(L.Settings_DreadsailReef_Header, RaidNotifier:GetRaidDescription(RAID_DREADSAIL_REEF))
+	MakeControlEntry({
+		type = "checkbox",
+		name = L.Settings_DreadsailReef_Imminent_Debuffs,
+		tooltip = L.Settings_DreadsailReef_Imminent_Debuffs_TT,
+	}, "dreadsailReef", "imminent_debuffs")
 	subTable = nil --end submenu
 
 	MakeControlEntry({

--- a/TrialDreadsailReef.lua
+++ b/TrialDreadsailReef.lua
@@ -39,6 +39,13 @@ function RaidNotifier.DSR.OnCombatEvent(_, result, isError, aName, aGraphic, aAc
             elseif (tName ~= "") then
                 self:StartCountdown(hitValue, zo_strformat(GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_IMMINENT_CHILL_OTHER), tName), "dreadsailReef", "imminent_debuffs", true)
             end
+        -- Tideborn Taleria's Rapid Deluge
+        elseif (buffsDebuffs.taleria_rapid_deluge[abilityId] and settings.taleria_rapid_deluge > 0) then
+            if (tType == COMBAT_UNIT_TYPE_PLAYER) then
+                self:StartCountdown(hitValue, GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_RAPID_DELUGE), "dreadsailReef", "taleria_rapid_deluge", true)
+            elseif (settings.taleria_rapid_deluge == 2 and tName ~= "") then
+                self:StartCountdown(hitValue, zo_strformat(GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_RAPID_DELUGE_OTHER), tName), "dreadsailReef", "taleria_rapid_deluge", true)
+            end
         end
     end
 end

--- a/TrialDreadsailReef.lua
+++ b/TrialDreadsailReef.lua
@@ -24,7 +24,23 @@ function RaidNotifier.DSR.OnCombatEvent(_, result, isError, aName, aGraphic, aAc
         tName = self.UnitIdToString(tUnitId)
     end
 
-    if (result == ACTION_RESULT_EFFECT_GAINED_DURATION) then
+    if (result == ACTION_RESULT_BEGIN) then
+        -- Lylanar's Heavy Attack
+        if (abilityId == buffsDebuffs.lylanar_broiling_hew and settings.brothers_heavy_attack > 0) then
+            if (tType == COMBAT_UNIT_TYPE_PLAYER) then
+                self:AddAnnouncement(GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_BROILING_HEW), "dreadsailReef", "brothers_heavy_attack")
+            elseif (settings.brothers_heavy_attack == 2 and tName ~= "") then
+                self:AddAnnouncement(zo_strformat(GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_BROILING_HEW_OTHER), tName), "dreadsailReef", "brothers_heavy_attack")
+            end
+        -- Turlassil's Heavy Attack
+        elseif (abilityId == buffsDebuffs.turlassil_stinging_shear and settings.brothers_heavy_attack > 0) then
+            if (tType == COMBAT_UNIT_TYPE_PLAYER) then
+                self:AddAnnouncement(GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_STINGING_SHEAR), "dreadsailReef", "brothers_heavy_attack")
+            elseif (settings.brothers_heavy_attack == 2 and tName ~= "") then
+                self:AddAnnouncement(zo_strformat(GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_STINGING_SHEAR_OTHER), tName), "dreadsailReef", "brothers_heavy_attack")
+            end
+        end
+    elseif (result == ACTION_RESULT_EFFECT_GAINED_DURATION) then
         -- Lylanar's Imminent Blister debuff
         if (abilityId == buffsDebuffs.lylanar_imminent_blister and settings.imminent_debuffs) then
             if (tType == COMBAT_UNIT_TYPE_PLAYER) then

--- a/TrialDreadsailReef.lua
+++ b/TrialDreadsailReef.lua
@@ -1,0 +1,26 @@
+RaidNotifier = RaidNotifier or {}
+RaidNotifier.DSR = {}
+
+local RaidNotifier = RaidNotifier
+
+local function p() end
+local function dbg() end
+
+local data = {}
+
+function RaidNotifier.DSR.Initialize()
+    p = RaidNotifier.p
+    dbg = RaidNotifier.dbg
+
+    data = {}
+end
+
+function RaidNotifier.DSR.OnCombatEvent(_, result, isError, aName, aGraphic, aActionSlotType, sName, sType, tName, tType, hitValue, pType, dType, log, sUnitId, tUnitId, abilityId)
+    local raidId = RaidNotifier.raidId
+    local self   = RaidNotifier
+    local buffsDebuffs, settings = self.BuffsDebuffs[raidId], self.Vars.dreadsailReef
+
+    if (tName == nil or tName == "") then
+        tName = self.UnitIdToString(tUnitId)
+    end
+end

--- a/TrialDreadsailReef.lua
+++ b/TrialDreadsailReef.lua
@@ -23,4 +23,22 @@ function RaidNotifier.DSR.OnCombatEvent(_, result, isError, aName, aGraphic, aAc
     if (tName == nil or tName == "") then
         tName = self.UnitIdToString(tUnitId)
     end
+
+    if (result == ACTION_RESULT_EFFECT_GAINED_DURATION) then
+        -- Lylanar's Imminent Blister debuff
+        if (abilityId == buffsDebuffs.lylanar_imminent_blister and settings.imminent_debuffs) then
+            if (tType == COMBAT_UNIT_TYPE_PLAYER) then
+                self:StartCountdown(hitValue, GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_IMMINENT_BLISTER), "dreadsailReef", "imminent_debuffs", true)
+            elseif (tName ~= "") then
+                self:StartCountdown(hitValue, zo_strformat(GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_IMMINENT_BLISTER_OTHER), tName), "dreadsailReef", "imminent_debuffs", true)
+            end
+        -- Turlassil's Imminent Chill debuff
+        elseif (abilityId == buffsDebuffs.turlassil_imminent_chill and settings.imminent_debuffs) then
+            if (tType == COMBAT_UNIT_TYPE_PLAYER) then
+                self:StartCountdown(hitValue, GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_IMMINENT_CHILL), "dreadsailReef", "imminent_debuffs", true)
+            elseif (tName ~= "") then
+                self:StartCountdown(hitValue, zo_strformat(GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_IMMINENT_CHILL_OTHER), tName), "dreadsailReef", "imminent_debuffs", true)
+            end
+        end
+    end
 end

--- a/TrialDreadsailReef.lua
+++ b/TrialDreadsailReef.lua
@@ -13,6 +13,13 @@ function RaidNotifier.DSR.Initialize()
     dbg = RaidNotifier.dbg
 
     data = {}
+    data.reefHeartCounter = 0
+end
+
+function RaidNotifier.DSR.OnCombatStateChanged(inCombat)
+    if inCombat then
+        data.reefHeartCounter = 0
+    end
 end
 
 function RaidNotifier.DSR.OnCombatEvent(_, result, isError, aName, aGraphic, aActionSlotType, sName, sType, tName, tType, hitValue, pType, dType, log, sUnitId, tUnitId, abilityId)
@@ -39,6 +46,13 @@ function RaidNotifier.DSR.OnCombatEvent(_, result, isError, aName, aGraphic, aAc
             elseif (settings.brothers_heavy_attack == 2 and tName ~= "") then
                 self:AddAnnouncement(zo_strformat(GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_STINGING_SHEAR_OTHER), tName), "dreadsailReef", "brothers_heavy_attack")
             end
+        elseif (abilityId == buffsDebuffs.reef_guardian_heartburn and settings.reef_guardian_reef_heart) then
+            data.reefHeartCounter = data.reefHeartCounter + 1
+            self:AddAnnouncement(
+                zo_strformat(GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_REEFGUARDIAN_REEFHEART), data.reefHeartCounter),
+                "dreadsailReef",
+                "reef_guardian_reef_heart"
+            )
         end
     elseif (result == ACTION_RESULT_EFFECT_GAINED_DURATION) then
         -- Lylanar's Imminent Blister debuff

--- a/lang/en.lua
+++ b/lang/en.lua
@@ -634,6 +634,8 @@ L.Settings_DreadsailReef_Imminent_Debuffs          = "Lylanar & Turlassil: Immin
 L.Settings_DreadsailReef_Imminent_Debuffs_TT       = "Alerts you when tank receives Imminent Blister debuff from Lylanar or Imminent Chill debuff from Turlassil. Tanks should swap in 10 seconds."
 L.Settings_DreadsailReef_Brothers_Heavy_Attack     = "Lylanar & Turlassil: Heavy attack"
 L.Settings_DreadsailReef_Brothers_Heavy_Attack_TT  = "Alerts you when Lylanar or Turlassil makes their heavy attack (Broiling Hew / Stinging Shear)."
+L.Settings_DreadsailReef_ReefGuardian_ReefHeart    = "Reef Guardian: Reef Heart spawn"
+L.Settings_DreadsailReef_ReefGuardian_ReefHeart_TT = "Alerts you when Reef Heart appears. You have 60 seconds to kill it or it's a group wipe. There can be several Hearts active at the same time."
 L.Settings_DreadsailReef_Rapid_Deluge              = "Taleria: Rapid Deluge"
 L.Settings_DreadsailReef_Rapid_Deluge_TT           = "Alerts you when you or someone got Rapid Deluge debuff. They'll explode in 6 seconds, and the best option to handle the damage is to be swimming at that time."
 
@@ -646,6 +648,7 @@ L.Alerts_DreadsailReef_Broiling_Hew                = "Incoming |cCDCDCDBroiling 
 L.Alerts_DreadsailReef_Broiling_Hew_Other          = "Incoming |cCDCDCDBroiling Hew|r on |cFF0000<<!aC:1>>|r!"
 L.Alerts_DreadsailReef_Stinging_Shear              = "Incoming |cCDCDCDStinging Shear|r on you!"
 L.Alerts_DreadsailReef_Stinging_Shear_Other        = "Incoming |cCDCDCDStinging Shear|r on |cFF0000<<!aC:1>>|r!"
+L.Alerts_DreadsailReef_ReefGuardian_ReefHeart      = "Reef Heart #|cFF0000<<1>>|r spawned!"
 L.Alerts_DreadsailReef_Rapid_Deluge                = "You got |c1CA3ECRapid Deluge|r! You should be swimming in"
 L.Alerts_DreadsailReef_Rapid_Deluge_Other          = "|cFF0000<<!aC:1>>|r got |c1CA3ECRapid Deluge|r! Swim in"
 

--- a/lang/en.lua
+++ b/lang/en.lua
@@ -630,8 +630,14 @@ L.Alerts_Rockgrove_Embrace_Of_Death_Other          = "|cFF0000<<!aC:1>>|r cursed
 --------------------------------
 L.Settings_DreadsailReef_Header                    = "Dreadsail Reef"
 -- Settings
+L.Settings_DreadsailReef_Imminent_Debuffs          = "Lylanar & Turlassil: Imminent Blister/Chill"
+L.Settings_DreadsailReef_Imminent_Debuffs_TT       = "Alerts you when tank receives Imminent Blister debuff from Lylanar or Imminent Chill debuff from Turlassil. Tanks should swap in 10 seconds."
 
 -- Alerts
+L.Alerts_DreadsailReef_Imminent_Blister            = "You're afflicted by |cF27D0CImminent Blister|r! Swap tanks until"
+L.Alerts_DreadsailReef_Imminent_Blister_Other      = "|cFF0000<<!aC:1>>|r afflicted by |cF27D0CImminent Blister|r! Swap tanks until"
+L.Alerts_DreadsailReef_Imminent_Chill              = "You're afflicted by |cB4CFFAImminent Chill|r! Swap tanks until"
+L.Alerts_DreadsailReef_Imminent_Chill_Other        = "|cFF0000<<!aC:1>>|r afflicted by |cB4CFFAImminent Chill|r! Swap tanks until"
 
 
 --------------------------------

--- a/lang/en.lua
+++ b/lang/en.lua
@@ -632,12 +632,16 @@ L.Settings_DreadsailReef_Header                    = "Dreadsail Reef"
 -- Settings
 L.Settings_DreadsailReef_Imminent_Debuffs          = "Lylanar & Turlassil: Imminent Blister/Chill"
 L.Settings_DreadsailReef_Imminent_Debuffs_TT       = "Alerts you when tank receives Imminent Blister debuff from Lylanar or Imminent Chill debuff from Turlassil. Tanks should swap in 10 seconds."
+L.Settings_DreadsailReef_Rapid_Deluge              = "Taleria: Rapid Deluge"
+L.Settings_DreadsailReef_Rapid_Deluge_TT           = "Alerts you when you or someone got Rapid Deluge debuff. They'll explode in 6 seconds, and the best option to handle the damage is to be swimming at that time."
 
 -- Alerts
 L.Alerts_DreadsailReef_Imminent_Blister            = "You're afflicted by |cF27D0CImminent Blister|r! Swap tanks until"
 L.Alerts_DreadsailReef_Imminent_Blister_Other      = "|cFF0000<<!aC:1>>|r afflicted by |cF27D0CImminent Blister|r! Swap tanks until"
 L.Alerts_DreadsailReef_Imminent_Chill              = "You're afflicted by |cB4CFFAImminent Chill|r! Swap tanks until"
 L.Alerts_DreadsailReef_Imminent_Chill_Other        = "|cFF0000<<!aC:1>>|r afflicted by |cB4CFFAImminent Chill|r! Swap tanks until"
+L.Alerts_DreadsailReef_Rapid_Deluge                = "You got |c1CA3ECRapid Deluge|r! You should be swimming in"
+L.Alerts_DreadsailReef_Rapid_Deluge_Other          = "|cFF0000<<!aC:1>>|r got |c1CA3ECRapid Deluge|r! Swim in"
 
 
 --------------------------------

--- a/lang/en.lua
+++ b/lang/en.lua
@@ -626,6 +626,15 @@ L.Alerts_Rockgrove_Embrace_Of_Death_Other          = "|cFF0000<<!aC:1>>|r cursed
 
 
 --------------------------------
+------   DREADSAIL REEF    -----
+--------------------------------
+L.Settings_DreadsailReef_Header                    = "Dreadsail Reef"
+-- Settings
+
+-- Alerts
+
+
+--------------------------------
 ----       Debugging        ----
 --------------------------------
 L.Settings_Debug_Header                  = "Debug"

--- a/lang/en.lua
+++ b/lang/en.lua
@@ -632,6 +632,8 @@ L.Settings_DreadsailReef_Header                    = "Dreadsail Reef"
 -- Settings
 L.Settings_DreadsailReef_Imminent_Debuffs          = "Lylanar & Turlassil: Imminent Blister/Chill"
 L.Settings_DreadsailReef_Imminent_Debuffs_TT       = "Alerts you when tank receives Imminent Blister debuff from Lylanar or Imminent Chill debuff from Turlassil. Tanks should swap in 10 seconds."
+L.Settings_DreadsailReef_Brothers_Heavy_Attack     = "Lylanar & Turlassil: Heavy attack"
+L.Settings_DreadsailReef_Brothers_Heavy_Attack_TT  = "Alerts you when Lylanar or Turlassil makes their heavy attack (Broiling Hew / Stinging Shear)."
 L.Settings_DreadsailReef_Rapid_Deluge              = "Taleria: Rapid Deluge"
 L.Settings_DreadsailReef_Rapid_Deluge_TT           = "Alerts you when you or someone got Rapid Deluge debuff. They'll explode in 6 seconds, and the best option to handle the damage is to be swimming at that time."
 
@@ -640,6 +642,10 @@ L.Alerts_DreadsailReef_Imminent_Blister            = "You're afflicted by |cF27D
 L.Alerts_DreadsailReef_Imminent_Blister_Other      = "|cFF0000<<!aC:1>>|r afflicted by |cF27D0CImminent Blister|r! Swap tanks until"
 L.Alerts_DreadsailReef_Imminent_Chill              = "You're afflicted by |cB4CFFAImminent Chill|r! Swap tanks until"
 L.Alerts_DreadsailReef_Imminent_Chill_Other        = "|cFF0000<<!aC:1>>|r afflicted by |cB4CFFAImminent Chill|r! Swap tanks until"
+L.Alerts_DreadsailReef_Broiling_Hew                = "Incoming |cCDCDCDBroiling Hew|r on you!"
+L.Alerts_DreadsailReef_Broiling_Hew_Other          = "Incoming |cCDCDCDBroiling Hew|r on |cFF0000<<!aC:1>>|r!"
+L.Alerts_DreadsailReef_Stinging_Shear              = "Incoming |cCDCDCDStinging Shear|r on you!"
+L.Alerts_DreadsailReef_Stinging_Shear_Other        = "Incoming |cCDCDCDStinging Shear|r on |cFF0000<<!aC:1>>|r!"
 L.Alerts_DreadsailReef_Rapid_Deluge                = "You got |c1CA3ECRapid Deluge|r! You should be swimming in"
 L.Alerts_DreadsailReef_Rapid_Deluge_Other          = "|cFF0000<<!aC:1>>|r got |c1CA3ECRapid Deluge|r! Swim in"
 


### PR DESCRIPTION
I have plans to cover new trial more, but unfortunately little time.
So it'll be wiser to publish that part that I managed to develop.

---

Version 2.22
CHANGELOG:
- Added Lylanar&Turlassil heavy attack announcements
- Added Lylanar&Turlassil Imminent Blister/Chill debuff countdowns
- Added Reef Heart spawn alert at the Reef Guardian boss fight
- Added Taleria's Rapid Deluge countdown