### PR TITLE
Version 2.23: DSR mechanic & fix

### DIFF
--- a/BuffsDebuffs.lua
+++ b/BuffsDebuffs.lua
@@ -655,6 +655,10 @@ dreadsail_reef.turlassil_imminent_chill = 168526
 dreadsail_reef.lylanar_broiling_hew = 167273
 -- Turlassil's Heavy Attack
 dreadsail_reef.turlassil_stinging_shear = 167280
+-- Destructive Ember (Fire Dome)
+dreadsail_reef.destructive_ember = 166209
+-- Piercing Hailstone (Ice Dome)
+dreadsail_reef.piercing_hailstone = 166178
 -- Reef Guardian's cast on Reef Heart
 dreadsail_reef.reef_guardian_heartburn = 163692
 -- Tideborn Taleria's Rapid Deluge

--- a/BuffsDebuffs.lua
+++ b/BuffsDebuffs.lua
@@ -661,6 +661,12 @@ dreadsail_reef.destructive_ember = 166209
 dreadsail_reef.piercing_hailstone = 166178
 -- Reef Guardian's cast on Reef Heart
 dreadsail_reef.reef_guardian_heartburn = 163692
+-- Reef Guardian's buff that Reef Heart receives (60s)
+dreadsail_reef.reef_guardian_heartburn_buff = 170481
+-- Vulnerability in case Heart was destroyed in time
+dreadsail_reef.reef_guardian_heartburn_vulnerability = 166031
+-- Empowerment in case Heart wasn't destroyed in time
+dreadsail_reef.reef_guardian_heartburn_empowerment = 166032
 -- Tideborn Taleria's Rapid Deluge
 dreadsail_reef.taleria_rapid_deluge = {
 	[174959] = true, -- Normal

--- a/RaidNotifier.lua
+++ b/RaidNotifier.lua
@@ -5,7 +5,7 @@ local RaidNotifier = RaidNotifier
 
 RaidNotifier.Name           = "RaidNotifier"
 RaidNotifier.DisplayName    = "Raid Notifier"
-RaidNotifier.Version        = "2.22"
+RaidNotifier.Version        = "2.23"
 RaidNotifier.Author         = "|c009ad6Kyoma, Memus, Woeler, silentgecko|r"
 RaidNotifier.SV_Name        = "RNVars"
 RaidNotifier.SV_Version     = 4

--- a/RaidNotifier.txt
+++ b/RaidNotifier.txt
@@ -1,7 +1,7 @@
 ## Title: |cEFEBBERaidNotifier|r
 ## Description: Displays on-screen notifications on different events during trials.
 ## Author: |c009ad6Kyoma, Memus, Woeler, silentgecko|r
-## Version: 2.22
+## Version: 2.23
 ## APIVersion: 101034
 ## SavedVariables: RNVars RN_DEBUG_LOG
 ## DependsOn: LibAddonMenu-2.0>=28 LibUnits2

--- a/Settings.lua
+++ b/Settings.lua
@@ -318,6 +318,7 @@ do ------------------
 			bahsei_embrace_of_death = 0, -- "Off"
 		},
 		dreadsailReef = {
+			dome_activation = false,
 			imminent_debuffs = false,
 			brothers_heavy_attack = 0, -- "Off"
 			reef_guardian_reef_heart = false,
@@ -1721,6 +1722,11 @@ function RaidNotifier:CreateSettingsMenu()
 
 	-- Dreadsail Reef
 	MakeSubmenu(L.Settings_DreadsailReef_Header, RaidNotifier:GetRaidDescription(RAID_DREADSAIL_REEF))
+	MakeControlEntry({
+		type = "checkbox",
+		name = L.Settings_DreadsailReef_Dome_Activation,
+		tooltip = L.Settings_DreadsailReef_Dome_Activation_TT,
+	}, "dreadsailReef", "dome_activation")
 	MakeControlEntry({
 		type = "checkbox",
 		name = L.Settings_DreadsailReef_Imminent_Debuffs,

--- a/Settings.lua
+++ b/Settings.lua
@@ -322,6 +322,7 @@ do ------------------
 			imminent_debuffs = false,
 			brothers_heavy_attack = 0, -- "Off"
 			reef_guardian_reef_heart = false,
+			reef_guardian_reef_heart_result = false,
 			taleria_rapid_deluge = 0, -- "Off"
 		},
 		dbg = {
@@ -1743,6 +1744,14 @@ function RaidNotifier:CreateSettingsMenu()
 		name = L.Settings_DreadsailReef_ReefGuardian_ReefHeart,
 		tooltip = L.Settings_DreadsailReef_ReefGuardian_ReefHeart_TT,
 	}, "dreadsailReef", "reef_guardian_reef_heart")
+	MakeControlEntry({
+		type = "checkbox",
+		name = L.Settings_DreadsailReef_ReefHeart_Result,
+		tooltip = L.Settings_DreadsailReef_ReefHeart_Result_TT,
+		disabled = function()
+			return savedVars.dreadsailReef.reef_guardian_reef_heart == false;
+		end,
+	}, "dreadsailReef", "reef_guardian_reef_heart_result")
 	MakeControlEntry({
 		type = "dropdown",
 		name = L.Settings_DreadsailReef_Rapid_Deluge,

--- a/TrialDreadsailReef.lua
+++ b/TrialDreadsailReef.lua
@@ -18,13 +18,11 @@ function RaidNotifier.DSR.Initialize()
 end
 
 function RaidNotifier.DSR.OnCombatStateChanged(inCombat)
-    if inCombat then
-        local bossCount, bossAlive, bossFull = RaidNotifier:GetNumBosses(true)
+    local bossCount, bossAlive, bossFull = RaidNotifier:GetNumBosses(true)
 
-        if bossCount == 0 or bossAlive == 0 or bossFull == bossCount then
-            data.reefHeartCounter = 0
-            data.reefHearts = {}
-        end
+    if bossCount == 0 or bossAlive == 0 or bossFull == bossCount then
+        data.reefHeartCounter = 0
+        data.reefHearts = {}
     end
 end
 

--- a/TrialDreadsailReef.lua
+++ b/TrialDreadsailReef.lua
@@ -50,6 +50,7 @@ function RaidNotifier.DSR.OnCombatEvent(_, result, isError, aName, aGraphic, aAc
             elseif (settings.brothers_heavy_attack == 2 and tName ~= "") then
                 self:AddAnnouncement(zo_strformat(GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_STINGING_SHEAR_OTHER), tName), "dreadsailReef", "brothers_heavy_attack")
             end
+        -- Reef Guardian's Heartburn cast on Reef Heart
         elseif (abilityId == buffsDebuffs.reef_guardian_heartburn and settings.reef_guardian_reef_heart) then
             data.reefHeartCounter = data.reefHeartCounter + 1
             self:AddAnnouncement(

--- a/TrialDreadsailReef.lua
+++ b/TrialDreadsailReef.lua
@@ -18,7 +18,11 @@ end
 
 function RaidNotifier.DSR.OnCombatStateChanged(inCombat)
     if inCombat then
-        data.reefHeartCounter = 0
+        local bossCount, bossAlive, bossFull = RaidNotifier:GetNumBosses(true)
+
+        if bossCount == 0 or bossAlive == 0 or bossFull == bossCount then
+            data.reefHeartCounter = 0
+        end
     end
 end
 

--- a/TrialDreadsailReef.lua
+++ b/TrialDreadsailReef.lua
@@ -82,5 +82,21 @@ function RaidNotifier.DSR.OnCombatEvent(_, result, isError, aName, aGraphic, aAc
                 self:StartCountdown(hitValue, zo_strformat(GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_RAPID_DELUGE_OTHER), tName), "dreadsailReef", "taleria_rapid_deluge", true)
             end
         end
+    elseif (result == ACTION_RESULT_EFFECT_GAINED) then
+        -- Player activated Fire Dome at the Lylanar&Turlassil encounter
+        if (abilityId == buffsDebuffs.destructive_ember and settings.dome_activation and tName ~= "") then
+            self:AddAnnouncement(
+                zo_strformat(GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_DESTRUCTIVE_EMBER), tName),
+                "dreadsailReef",
+                "dome_activation"
+            )
+        -- Player activated Ice Dome at the Lylanar&Turlassil encounter
+        elseif (abilityId == buffsDebuffs.piercing_hailstone and settings.dome_activation and tName ~= "") then
+            self:AddAnnouncement(
+                zo_strformat(GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_PIERCING_HAILSTONE), tName),
+                "dreadsailReef",
+                "dome_activation"
+            )
+        end
     end
 end

--- a/lang/en.lua
+++ b/lang/en.lua
@@ -638,6 +638,8 @@ L.Settings_DreadsailReef_Brothers_Heavy_Attack     = "Lylanar & Turlassil: Heavy
 L.Settings_DreadsailReef_Brothers_Heavy_Attack_TT  = "Alerts you when Lylanar or Turlassil makes their heavy attack (Broiling Hew / Stinging Shear)."
 L.Settings_DreadsailReef_ReefGuardian_ReefHeart    = "Reef Guardian: Reef Heart spawn"
 L.Settings_DreadsailReef_ReefGuardian_ReefHeart_TT = "Alerts you when Reef Heart appears. You have 60 seconds to kill it or it's a group wipe. There can be several Hearts active at the same time."
+L.Settings_DreadsailReef_ReefHeart_Result          = "Reef Guardian: Reef Heart success/failure"
+L.Settings_DreadsailReef_ReefHeart_Result_TT       = "Alerts you if you have executed Reef Heart or not."
 L.Settings_DreadsailReef_Rapid_Deluge              = "Taleria: Rapid Deluge"
 L.Settings_DreadsailReef_Rapid_Deluge_TT           = "Alerts you when you or someone got Rapid Deluge debuff. They'll explode in 6 seconds, and the best option to handle the damage is to be swimming at that time."
 
@@ -653,6 +655,10 @@ L.Alerts_DreadsailReef_Broiling_Hew_Other          = "Incoming |cCDCDCDBroiling 
 L.Alerts_DreadsailReef_Stinging_Shear              = "Incoming |cCDCDCDStinging Shear|r on you!"
 L.Alerts_DreadsailReef_Stinging_Shear_Other        = "Incoming |cCDCDCDStinging Shear|r on |cFF0000<<!aC:1>>|r!"
 L.Alerts_DreadsailReef_ReefGuardian_ReefHeart      = "Reef Heart #|cFF0000<<1>>|r spawned!"
+L.Alerts_DreadsailReef_ReefHeart_Success           = "Reef Heart #|cFF0000<<1>>|r |c7CFC00destroyed|r!"
+L.Alerts_DreadsailReef_ReefHeart_Success_Unknown   = "Reef Heart |c7CFC00destroyed|r!"
+L.Alerts_DreadsailReef_ReefHeart_Failure           = "Reef Heart #|cFF0000<<1>>|r |cFF0000empowered|r. You're doomed!"
+L.Alerts_DreadsailReef_ReefHeart_Failure_Unknown   = "Reef Heart |cFF0000empowered|r. You're doomed!"
 L.Alerts_DreadsailReef_Rapid_Deluge                = "You got |c1CA3ECRapid Deluge|r! You should be swimming in"
 L.Alerts_DreadsailReef_Rapid_Deluge_Other          = "|cFF0000<<!aC:1>>|r got |c1CA3ECRapid Deluge|r! Swim in"
 

--- a/lang/en.lua
+++ b/lang/en.lua
@@ -630,6 +630,8 @@ L.Alerts_Rockgrove_Embrace_Of_Death_Other          = "|cFF0000<<!aC:1>>|r cursed
 --------------------------------
 L.Settings_DreadsailReef_Header                    = "Dreadsail Reef"
 -- Settings
+L.Settings_DreadsailReef_Dome_Activation           = "Lylanar & Turlassil: Fire/Ice Dome activation"
+L.Settings_DreadsailReef_Dome_Activation_TT        = "Alerts you when someone gets Fire or Ice Dome."
 L.Settings_DreadsailReef_Imminent_Debuffs          = "Lylanar & Turlassil: Imminent Blister/Chill"
 L.Settings_DreadsailReef_Imminent_Debuffs_TT       = "Alerts you when tank receives Imminent Blister debuff from Lylanar or Imminent Chill debuff from Turlassil. Tanks should swap in 10 seconds."
 L.Settings_DreadsailReef_Brothers_Heavy_Attack     = "Lylanar & Turlassil: Heavy attack"
@@ -640,6 +642,8 @@ L.Settings_DreadsailReef_Rapid_Deluge              = "Taleria: Rapid Deluge"
 L.Settings_DreadsailReef_Rapid_Deluge_TT           = "Alerts you when you or someone got Rapid Deluge debuff. They'll explode in 6 seconds, and the best option to handle the damage is to be swimming at that time."
 
 -- Alerts
+L.Alerts_DreadsailReef_Destructive_Ember           = "<<!aC:1>> activated |cFFA500Fire Dome|r!"
+L.Alerts_DreadsailReef_Piercing_Hailstone          = "<<!aC:1>> activated |c20C3D0Ice Dome|r!"
 L.Alerts_DreadsailReef_Imminent_Blister            = "You're afflicted by |cF27D0CImminent Blister|r! Swap tanks until"
 L.Alerts_DreadsailReef_Imminent_Blister_Other      = "|cFF0000<<!aC:1>>|r afflicted by |cF27D0CImminent Blister|r! Swap tanks until"
 L.Alerts_DreadsailReef_Imminent_Chill              = "You're afflicted by |cB4CFFAImminent Chill|r! Swap tanks until"


### PR DESCRIPTION
Version 2.23:
- Fixed Reef Guardian's Reef Heart counter reset trigger (previously your death reset it, not anymore)
- Added Dome activation alert at the Lylanar&Turlassil encounter
- Added alert if Reef Heart was destroyed in time or not at the Reef Guardian encounter