### PR TITLE
Version 2.24: Z'maja's Shadow Splash notification, minor Dreadsail Reef bugfix, API bump

### DIFF
--- a/BuffsDebuffs.lua
+++ b/BuffsDebuffs.lua
@@ -485,6 +485,7 @@ cloudrest.player_exit_srealm = 105218
 cloudrest.malicious_strike = {}
 cloudrest.malicious_strike[110242] = true -- veteran
 cloudrest.malicious_strike[105363] = true -- normal
+cloudrest.shadow_splash = 105123
 
 cloudrest.interest_list = {}
 

--- a/RaidNotifier.lua
+++ b/RaidNotifier.lua
@@ -5,7 +5,7 @@ local RaidNotifier = RaidNotifier
 
 RaidNotifier.Name           = "RaidNotifier"
 RaidNotifier.DisplayName    = "Raid Notifier"
-RaidNotifier.Version        = "2.23"
+RaidNotifier.Version        = "2.24"
 RaidNotifier.Author         = "|c009ad6Kyoma, Memus, Woeler, silentgecko|r"
 RaidNotifier.SV_Name        = "RNVars"
 RaidNotifier.SV_Version     = 4

--- a/RaidNotifier.txt
+++ b/RaidNotifier.txt
@@ -1,7 +1,7 @@
 ## Title: |cEFEBBERaidNotifier|r
 ## Description: Displays on-screen notifications on different events during trials.
 ## Author: |c009ad6Kyoma, Memus, Woeler, silentgecko|r
-## Version: 2.23
+## Version: 2.24
 ## APIVersion: 101036
 ## SavedVariables: RNVars RN_DEBUG_LOG
 ## DependsOn: LibAddonMenu-2.0>=28 LibUnits2

--- a/RaidNotifier.txt
+++ b/RaidNotifier.txt
@@ -2,7 +2,7 @@
 ## Description: Displays on-screen notifications on different events during trials.
 ## Author: |c009ad6Kyoma, Memus, Woeler, silentgecko|r
 ## Version: 2.23
-## APIVersion: 101034
+## APIVersion: 101036
 ## SavedVariables: RNVars RN_DEBUG_LOG
 ## DependsOn: LibAddonMenu-2.0>=28 LibUnits2
 ## OptionalDependsOn: LibGroupSocket

--- a/Settings.lua
+++ b/Settings.lua
@@ -281,6 +281,7 @@ do ------------------
 			crushing_darkness = 1, -- "Self"
 			tentacle_spawn = false,
 			break_amulet = false,
+			shadow_splash = false,
 		},
 		sunspire = {
 			chilling_comet = 1, -- "Self"
@@ -1537,6 +1538,11 @@ function RaidNotifier:CreateSettingsMenu()
 		tooltip = L.Settings_Cloudrest_Crushing_Darkness_TT,
 		choices = choices.cloudrest.crushing_darkness,
 	}, "cloudrest", "crushing_darkness")
+	MakeControlEntry({
+		type = "checkbox",
+		name = L.Settings_Cloudrest_Shadow_Splash,
+		tooltip = L.Settings_Cloudrest_Shadow_Splash_TT,
+	}, "cloudrest", "shadow_splash")
 	subTable = nil --end submenu
 
 	MakeSubmenu(L.Settings_Sunspire_Header, RaidNotifier:GetRaidDescription(RAID_SUNSPIRE))

--- a/TrialCloudrest.lua
+++ b/TrialCloudrest.lua
@@ -156,6 +156,8 @@ function RaidNotifier.CR.OnCombatEvent(_, result, isError, aName, aGraphic, aAct
 					self:StartCountdown(6500, zo_strformat(GetString(RAIDNOTIFIER_ALERTS_CLOUDREST_ROARING_FLARE_OTHER), tName), "cloudrest", "roaring_flare", false)
 				end
 			end
+		elseif abilityId == buffsDebuffs.shadow_splash then
+			self:AddAnnouncement(GetString(RAIDNOTIFIER_ALERTS_CLOUDREST_SHADOW_SPLASH), "cloudrest", "shadow_splash")
 		end
 	elseif result == ACTION_RESULT_EFFECT_GAINED then
 		if (abilityId == buffsDebuffs.start_cd_of_srealm) then

--- a/TrialDreadsailReef.lua
+++ b/TrialDreadsailReef.lua
@@ -71,7 +71,7 @@ function RaidNotifier.DSR.OnCombatEvent(_, result, isError, aName, aGraphic, aAc
             if (tType == COMBAT_UNIT_TYPE_PLAYER) then
                 self:StartCountdown(hitValue, GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_RAPID_DELUGE), "dreadsailReef", "taleria_rapid_deluge", true)
             elseif (settings.taleria_rapid_deluge == 2 and tName ~= "") then
-                self:StartCountdown(hitValue, zo_strformat(GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_RAPID_DELUGE_OTHER), tName), "dreadsailReef", "taleria_rapid_deluge", true)
+                self:StartCountdown(hitValue, zo_strformat(GetString(RAIDNOTIFIER_ALERTS_DREADSAILREEF_RAPID_DELUGE_OTHER), tName), "dreadsailReef", "taleria_rapid_deluge", false)
             end
         end
     elseif (result == ACTION_RESULT_EFFECT_GAINED) then

--- a/lang/en.lua
+++ b/lang/en.lua
@@ -460,6 +460,8 @@ L.Settings_Cloudrest_Crushing_Darkness          = "Z'Maja: Crushing Darkness"
 L.Settings_Cloudrest_Crushing_Darkness_TT       = "Alerts you when Tether AoE is following you and needs to be kited."
 L.Settings_Cloudrest_Malicious_Strike           = "Z'Maja: Malicious Strike"
 L.Settings_Cloudrest_Malicious_Strike_TT        = "Alerts when spheres are destroyed and need to block or rolldodge."
+L.Settings_Cloudrest_Shadow_Splash              = "Z'Maja: Shadow Splash"
+L.Settings_Cloudrest_Shadow_Splash_TT           = "Alerts you when Z'Maja starts channeling this spell. If not interrupted in time, some players will be teleported into the sky and take fall damage."
 
 -- Alerts
 L.Alerts_Cloudrest_Olorime_Spears               = "|cffd000Spear|r is up! (<<1>>)"
@@ -489,6 +491,7 @@ L.Alerts_Cloudrest_Sum_Shadow_Beads             = "|cab82ffSpheres|r are about t
 L.Alerts_Cloudrest_Nocturnals_Favor             = "|cff0000Nocturnal's Favor|r at you!"
 L.Alerts_Cloudrest_Crushing_Darkness            = "|cfc0c66Crushing Darkness|r at you. Kite!"
 L.Alerts_Cloudrest_Malicious_Strike             = "|cff0000Malicious Strike|r at you. Block!"
+L.Alerts_Cloudrest_Shadow_Splash                = "Z'Maja is casting. |cFF0000Interrupt|r!"
 
 --------------------------------
 ------   SUNSPIRE          -----

--- a/lang/fr.lua
+++ b/lang/fr.lua
@@ -539,7 +539,7 @@ L.Settings_Debug_Tracker_Header          = "Débogueur"
 L.Settings_Debug_Tracker_Description     = "Il s'agit d'une fonction de débogage destinée à suivre et à afficher les potentiels mécaniques au cours d'une épreuve en enregistrant les informations sur les évènements et les effets de combat. En raison de la quantité potentiellement importante d'informations, il existe quelques options pour éviter d'encombrer votre fenêtre de discussion."
 L.Settings_Debug_Tracker_Enabled         = "Activé"
 L.Settings_Debug_Tracker_SpamControl     = "Contrôle Anti-Spam"
-L.Settings_Debug_Tracker_SpamControl_TT  = "Avec cette option, chaque capacité / effet n'est enregistré qu'une fois par type d'action. La liste de ces capacités connues pour cette session peut être effacé avec :\n\n\ /rndebug clear"
+L.Settings_Debug_Tracker_SpamControl_TT  = "Avec cette option, chaque capacité / effet n'est enregistré qu'une fois par type d'action. La liste de ces capacités connues pour cette session peut être effacé avec :\n\n /rndebug clear"
 L.Settings_Debug_Tracker_MyEnemyOnly     = "Mon Ennemi Seulement"
 L.Settings_Debug_Tracker_MyEnemyOnly_TT  = "Lorsque l'option est activée, elle limitera TOUTE sortie de capacités / effets ciblés sur le joueur et qui ne proviennent pas du joueur ou du groupe. Utile lorsque vous cherchez une chose spécifique et que vous ne voulez pas que le Contrôle Anti-Spam s'active."
 


### PR DESCRIPTION
I'll be able to upload this version at esoui.com since I have access now thanks to @kyoma.
(upd.: and I already did it)
Unfortunately he missed my request about granting write access here 😅

So if we're going to keep this repository alive, I'll still have to ask your participation here @memus.
Thank you!

Changelog:
- Added Z'Maja's Shadow Splash notification in Cloudrest (it's the mechanic when you have to interrupt Z'maja)
- Fixed the bug when your own Rapid Deluge alert could be overrided (Dreadsail Reef)
- API version bump (Firesong DLC)
- Little fix in French localization which _may_ reduce the number of issues for those who use it.