### PR TITLE
Version 2.24.1: Fix for ignorance of Shadow Splash settings when notifying about it

### DIFF
--- a/RaidNotifier.lua
+++ b/RaidNotifier.lua
@@ -5,7 +5,7 @@ local RaidNotifier = RaidNotifier
 
 RaidNotifier.Name           = "RaidNotifier"
 RaidNotifier.DisplayName    = "Raid Notifier"
-RaidNotifier.Version        = "2.24"
+RaidNotifier.Version        = "2.24.1"
 RaidNotifier.Author         = "|c009ad6Kyoma, Memus, Woeler, silentgecko|r"
 RaidNotifier.SV_Name        = "RNVars"
 RaidNotifier.SV_Version     = 4

--- a/RaidNotifier.txt
+++ b/RaidNotifier.txt
@@ -1,7 +1,7 @@
 ## Title: |cEFEBBERaidNotifier|r
 ## Description: Displays on-screen notifications on different events during trials.
 ## Author: |c009ad6Kyoma, Memus, Woeler, silentgecko|r
-## Version: 2.24
+## Version: 2.24.1
 ## APIVersion: 101036
 ## SavedVariables: RNVars RN_DEBUG_LOG
 ## DependsOn: LibAddonMenu-2.0>=28 LibUnits2

--- a/TrialCloudrest.lua
+++ b/TrialCloudrest.lua
@@ -156,7 +156,7 @@ function RaidNotifier.CR.OnCombatEvent(_, result, isError, aName, aGraphic, aAct
 					self:StartCountdown(6500, zo_strformat(GetString(RAIDNOTIFIER_ALERTS_CLOUDREST_ROARING_FLARE_OTHER), tName), "cloudrest", "roaring_flare", false)
 				end
 			end
-		elseif abilityId == buffsDebuffs.shadow_splash then
+		elseif abilityId == buffsDebuffs.shadow_splash and settings.shadow_splash == true then
 			self:AddAnnouncement(GetString(RAIDNOTIFIER_ALERTS_CLOUDREST_SHADOW_SPLASH), "cloudrest", "shadow_splash")
 		end
 	elseif result == ACTION_RESULT_EFFECT_GAINED then


### PR DESCRIPTION
In 2.24 the announcement was introduced, but the part where it should be checked if announcement will be shown or not was sadly missing :D