### PR TITLE
Version 2.28: Added/adjusted some alerts for Rockgrove

### DIFF
--- a/RaidNotifier.lua
+++ b/RaidNotifier.lua
@@ -5,7 +5,7 @@ local RaidNotifier = RaidNotifier
 
 RaidNotifier.Name           = "RaidNotifier"
 RaidNotifier.DisplayName    = "Raid Notifier"
-RaidNotifier.Version        = "2.27.1"
+RaidNotifier.Version        = "2.28"
 RaidNotifier.Author         = "|c009ad6Kyoma, Memus, Woeler, silentgecko|r"
 RaidNotifier.SV_Name        = "RNVars"
 RaidNotifier.SV_Version     = 4

--- a/RaidNotifier.txt
+++ b/RaidNotifier.txt
@@ -1,8 +1,8 @@
 ## Title: |cEFEBBERaidNotifier|r
 ## Description: Displays on-screen notifications on different events during trials.
 ## Author: |c009ad6Kyoma, Memus, Woeler, silentgecko|r
-## Version: 2.27.1
-## APIVersion: 101039
+## Version: 2.28
+## APIVersion: 101041
 ## SavedVariables: RNVars RN_DEBUG_LOG
 ## DependsOn: LibAddonMenu-2.0>=28 LibUnits2
 ## OptionalDependsOn: LibGroupSocket

--- a/Settings.lua
+++ b/Settings.lua
@@ -318,6 +318,7 @@ do ------------------
 			oaxiltso_annihilator_cinder_cleave = 0, -- "Off"
 			bahsei_embrace_of_death = 0, -- "Off"
 			bahsei_cone_direction = false,
+			bahsei_portal_number = false,
 			xalvakka_unstable_charge = false,
 		},
 		dreadsailReef = {
@@ -1747,6 +1748,11 @@ function RaidNotifier:CreateSettingsMenu()
 		name = L.Settings_Rockgrove_Bahsei_Cone_Direction,
 		tooltip = L.Settings_Rockgrove_Bahsei_Cone_Direction_TT,
 	}, "rockgrove", "bahsei_cone_direction")
+	MakeControlEntry({
+		type = "checkbox",
+		name = L.Settings_Rockgrove_Bahsei_Portal_Number,
+		tooltip = L.Settings_Rockgrove_Bahsei_Portal_Number_TT,
+	}, "rockgrove", "bahsei_portal_number")
 	MakeControlEntry({
 		type = "checkbox",
 		name = L.Settings_Rockgrove_Xalvakka_Unstable_Charge,

--- a/Settings.lua
+++ b/Settings.lua
@@ -579,7 +579,12 @@ function RaidNotifier:CreateSettingsMenu()
 			sulxan_reaver_sundering_strike = off_self_all,
 			oaxiltso_noxious_sludge = off_self_all,
 			oaxiltso_annihilator_cinder_cleave = off_self_all,
-			bahsei_embrace_of_death = off_self_all,
+			bahsei_embrace_of_death = {
+				L.Settings_General_Choices_Off,
+				L.Settings_General_Choices_Self,
+				L.Settings_General_Choices_All,
+				L.Settings_General_Choices_SelfAndTanks,
+			},
 		},
 		dreadsailReef = {
 			dome_type = {
@@ -1741,7 +1746,7 @@ function RaidNotifier:CreateSettingsMenu()
 		name = L.Settings_Rockgrove_Embrace_Of_Death,
 		tooltip = L.Settings_Rockgrove_Embrace_Of_Death_TT,
 		choices = choices.rockgrove.bahsei_embrace_of_death,
-		choicesTooltips = { false, false, L.Settings_Rockgrove_Embrace_Of_Death_TT_All },
+		choicesTooltips = { false, false, L.Settings_Rockgrove_Embrace_Of_Death_TT_All, false },
 	}, "rockgrove", "bahsei_embrace_of_death")
 	MakeControlEntry({
 		type = "checkbox",

--- a/TrialRockgrove.lua
+++ b/TrialRockgrove.lua
@@ -13,6 +13,23 @@ function RaidNotifier.RG.Initialize()
     dbg = RaidNotifier.dbg
 
     data = {}
+    data.bahseiPortalCounter = 0
+end
+
+function RaidNotifier.RG.OnCombatStateChanged(inCombat)
+    if (inCombat and DoesUnitExist("boss1")) then
+        local currentHealth, maxHealth = GetUnitPower("boss1", POWERTYPE_HEALTH)
+
+        if currentHealth ~= nil and maxHealth ~= nil and currentHealth > 0 and maxHealth > 0 then
+            local healthPercent = currentHealth / maxHealth
+
+            if healthPercent <= 99 then
+                return
+            end
+        end
+    end
+
+    data.bahseiPortalCounter = 0
 end
 
 function RaidNotifier.RG.OnEffectChangedForGroup(eventCode, changeType, eSlot, eName, uTag, beginTime, endTime, stackCount, iconName, buffType, eType, aType, statusEffectType, uName, uId, abilityId, uType)
@@ -130,6 +147,12 @@ function RaidNotifier.RG.OnCombatEvent(_, result, isError, aName, aGraphic, aAct
         end
     elseif (result == ACTION_RESULT_EFFECT_GAINED) then
         if (abilityId == buffsDebuffs.bahsei_creeping_eye_clockwise or abilityId == buffsDebuffs.bahsei_creeping_eye_countercw) then
+            data.bahseiPortalCounter = data.bahseiPortalCounter % 2 + 1
+
+            if (settings.bahsei_portal_number) then
+                local text = zo_strformat(GetString(RAIDNOTIFIER_ALERTS_ROCKGROVE_BAHSEI_PORTAL_NUMBER), data.bahseiPortalCounter)
+                self:AddAnnouncement(text, "rockgrove", "bahsei_portal_number")
+            end
             if (settings.bahsei_cone_direction) then
                 local text
 

--- a/TrialRockgrove.lua
+++ b/TrialRockgrove.lua
@@ -2,6 +2,7 @@ RaidNotifier = RaidNotifier or {}
 RaidNotifier.RG = {}
 
 local RaidNotifier = RaidNotifier
+local Util = RaidNotifier.Util
 
 local function p() end
 local function dbg() end
@@ -78,7 +79,7 @@ function RaidNotifier.RG.OnEffectChangedForGroup(eventCode, changeType, eSlot, e
         if (changeType == EFFECT_RESULT_GAINED) then
             if (settings.bahsei_embrace_of_death >= 1 and AreUnitsEqual(uTag, "player")) then
                 self:StartCountdown(8000, GetString(RAIDNOTIFIER_ALERTS_ROCKGROVE_EMBRACE_OF_DEATH), "rockgrove", "bahsei_embrace_of_death", true)
-            elseif (settings.bahsei_embrace_of_death == 2) then
+            elseif (settings.bahsei_embrace_of_death == 2 or settings.bahsei_embrace_of_death == 3 and Util.isUnitTank(uTag)) then
                 local targetPlayerName = self.UnitIdToString(uId)
 
                 self:StartCountdown(8000, zo_strformat(GetString(RAIDNOTIFIER_ALERTS_ROCKGROVE_EMBRACE_OF_DEATH_OTHER), targetPlayerName), "rockgrove", "bahsei_embrace_of_death", false)

--- a/Util.lua
+++ b/Util.lua
@@ -194,3 +194,14 @@ function Util:GetDistance(pX, pY, tX, tY)
 	return dist
 end
 
+function Util:IsUnitTank(unitTag)
+	local isTank = false
+
+	if GetGroupSize() > 0 then
+		isTank = GetGroupMemberSelectedRole(unitTag) == LFG_ROLE_TANK
+	elseif AreUnitsEqual(unitTag, "player") then
+		isTank = GetSelectedLFGRole() == LFG_ROLE_TANK
+	end
+
+	return isTank
+end

--- a/lang/en.lua
+++ b/lang/en.lua
@@ -615,6 +615,8 @@ L.Settings_Rockgrove_Embrace_Of_Death_TT           = "Alerts you when someone go
 L.Settings_Rockgrove_Embrace_Of_Death_TT_All       = "|cFF0000WARNING!|r If your group will get too much curses your screen may be fully covered in countdowns for a duration of those curses! We're working on ways to improve this notification."
 L.Settings_Rockgrove_Bahsei_Cone_Direction         = "Flame-Herald Bahsei HM: Cone direction"
 L.Settings_Rockgrove_Bahsei_Cone_Direction_TT      = "Alerts you of the cone direction if the portal opened."
+L.Settings_Rockgrove_Bahsei_Portal_Number          = "Flame-Herald Bahsei HM: Portal number (beta)"
+L.Settings_Rockgrove_Bahsei_Portal_Number_TT       = "Tells you the number of portal being opened."
 L.Settings_Rockgrove_Xalvakka_Unstable_Charge      = "Xalvakka HM: Unstable charge (staying on blob)"
 L.Settings_Rockgrove_Xalvakka_Unstable_Charge_TT   = "Alerts you when you're staying on blob. It's not healthy!"
 
@@ -635,6 +637,7 @@ L.Alerts_Rockgrove_Embrace_Of_Death                = "You're cursed by |c0A929BE
 L.Alerts_Rockgrove_Embrace_Of_Death_Other          = "|cFF0000<<!aC:1>>|r cursed by |c0A929BEmbrace of Death|r! Explosion in"
 L.Alerts_Rockgrove_Bahsei_Cone_Direction_Clockwise = "-> Move |cF48020clockwise|r ->"
 L.Alerts_Rockgrove_Bahsei_Cone_Direction_CounterCW = "<- Move |c15FFC2counterclockwise|r <-"
+L.Alerts_Rockgrove_Bahsei_Portal_Number            = "Portal #<<1>>"
 L.Alerts_Rockgrove_Xalvakka_Unstable_Charge        = "Move away from |c008C22blob|r!"
 
 

--- a/lang/en.lua
+++ b/lang/en.lua
@@ -46,6 +46,7 @@ L.Settings_General_Choices_500ms                    = "0.5s"
 L.Settings_General_Choices_200ms                    = "0.2s"
 L.Settings_General_Choices_Custom                   = "Custom"
 L.Settings_General_Choices_Custom_Announcement      = "Custom (movable)"
+L.Settings_General_Choices_SelfAndTanks             = "Self and tanks"
 L.Settings_General_Choices_OnlyChaurusTotem         = "Only Chaurus" -- Specific for Kyne's Aegis
 L.Settings_DreadsailReef_Choices_OnlyFireDome       = "Only Fire Dome"
 L.Settings_DreadsailReef_Choices_OnlyIceDome        = "Only Ice Dome"


### PR DESCRIPTION
Changelog:
- Added alert about the portal number at Bahsei HM encounter [beta] (Rockgrove)
- Added option to enable Bahsei's curses announcement for yourself or tanks only (Rockgrove)