### PR TITLE
Version 2.28.1: Moved "isUnitTank" function in another table so the error screen won't popup

### DIFF
--- a/RaidNotifier.lua
+++ b/RaidNotifier.lua
@@ -5,7 +5,7 @@ local RaidNotifier = RaidNotifier
 
 RaidNotifier.Name           = "RaidNotifier"
 RaidNotifier.DisplayName    = "Raid Notifier"
-RaidNotifier.Version        = "2.28"
+RaidNotifier.Version        = "2.28.1"
 RaidNotifier.Author         = "|c009ad6Kyoma, Memus, Woeler, silentgecko|r"
 RaidNotifier.SV_Name        = "RNVars"
 RaidNotifier.SV_Version     = 4

--- a/RaidNotifier.txt
+++ b/RaidNotifier.txt
@@ -1,7 +1,7 @@
 ## Title: |cEFEBBERaidNotifier|r
 ## Description: Displays on-screen notifications on different events during trials.
 ## Author: |c009ad6Kyoma, Memus, Woeler, silentgecko|r
-## Version: 2.28
+## Version: 2.28.1
 ## APIVersion: 101041
 ## SavedVariables: RNVars RN_DEBUG_LOG
 ## DependsOn: LibAddonMenu-2.0>=28 LibUnits2

--- a/TrialRockgrove.lua
+++ b/TrialRockgrove.lua
@@ -2,12 +2,23 @@ RaidNotifier = RaidNotifier or {}
 RaidNotifier.RG = {}
 
 local RaidNotifier = RaidNotifier
-local Util = RaidNotifier.Util
 
 local function p() end
 local function dbg() end
 
 local data = {}
+
+local function isUnitTank(unitTag)
+    local isTank = false
+
+    if GetGroupSize() > 0 then
+        isTank = GetGroupMemberSelectedRole(unitTag) == LFG_ROLE_TANK
+    elseif AreUnitsEqual(unitTag, "player") then
+        isTank = GetSelectedLFGRole() == LFG_ROLE_TANK
+    end
+
+    return isTank
+end
 
 function RaidNotifier.RG.Initialize()
     p = RaidNotifier.p
@@ -79,7 +90,7 @@ function RaidNotifier.RG.OnEffectChangedForGroup(eventCode, changeType, eSlot, e
         if (changeType == EFFECT_RESULT_GAINED) then
             if (settings.bahsei_embrace_of_death >= 1 and AreUnitsEqual(uTag, "player")) then
                 self:StartCountdown(8000, GetString(RAIDNOTIFIER_ALERTS_ROCKGROVE_EMBRACE_OF_DEATH), "rockgrove", "bahsei_embrace_of_death", true)
-            elseif (settings.bahsei_embrace_of_death == 2 or settings.bahsei_embrace_of_death == 3 and Util.isUnitTank(uTag)) then
+            elseif (settings.bahsei_embrace_of_death == 2 or settings.bahsei_embrace_of_death == 3 and isUnitTank(uTag)) then
                 local targetPlayerName = self.UnitIdToString(uId)
 
                 self:StartCountdown(8000, zo_strformat(GetString(RAIDNOTIFIER_ALERTS_ROCKGROVE_EMBRACE_OF_DEATH_OTHER), targetPlayerName), "rockgrove", "bahsei_embrace_of_death", false)

--- a/Util.lua
+++ b/Util.lua
@@ -193,15 +193,3 @@ function Util:GetDistance(pX, pY, tX, tY)
 
 	return dist
 end
-
-function Util:IsUnitTank(unitTag)
-	local isTank = false
-
-	if GetGroupSize() > 0 then
-		isTank = GetGroupMemberSelectedRole(unitTag) == LFG_ROLE_TANK
-	elseif AreUnitsEqual(unitTag, "player") then
-		isTank = GetSelectedLFGRole() == LFG_ROLE_TANK
-	end
-
-	return isTank
-end


### PR DESCRIPTION
Not sure about the reasons, perhaps it is about the order of the loading.
In any case, currently I'm short in time for investigating, so I just moved the function inside the Rockgrove table, and now it works fine.
Planning to think about the best placement later on.